### PR TITLE
[4]Made auto-simplify as a parameter in octree and implemented Recursive simplify; Plus optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 itertools = { version = "0.10", default-features = false }
 hashbrown = { version = "0.11", default-features = false }
 micromath = { version = "2.0", optional = true }
+bendy = { version = "0.3.3" }
 
 [features]
 default = [ "std" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) use vector::Vector3;
 
 #[cfg(test)]
 mod tests {
-    use bendy::{encoding::ToBencode, decoding::FromBencode};
+    use bendy::{decoding::FromBencode, encoding::ToBencode};
 
     use super::*;
 
@@ -61,6 +61,32 @@ mod tests {
         assert!(matches!(octree.get([0, 0, 0]), Some(1)));
     }
 
+    #[test]
+    fn indexed_access() {
+        const DIM: u32 = 32;
+        let mut octree = Octree::<u32>::new(NonZeroU32::new(DIM as u32).unwrap()).unwrap();
+        for x in 0..DIM {
+            for y in 0..DIM {
+                for z in 0..DIM {
+                    let result = octree.insert([x as u32, y as u32, z as u32], (x + y + z + 1).into());
+                    assert!(result.is_ok());
+                }
+            }
+        }
+
+        for x in 0..DIM {
+            for y in 0..DIM {
+                for z in 0..DIM {
+                    let expected = x + y + z + 1;
+                    let result = octree.get([x as u32, y as u32, z as u32]);
+                    assert!(result.is_some());
+                    if let Some(value) = result {
+                        assert!(*value == expected);
+                    };
+                }
+            }
+        }
+    }
 
     #[test]
     fn basic_serialization() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub(crate) use vector::Vector3;
 
 #[cfg(test)]
 mod tests {
+    use bendy::{encoding::ToBencode, decoding::FromBencode};
+
     use super::*;
 
     use core::num::NonZeroU32;
@@ -55,6 +57,30 @@ mod tests {
 
         octree.clear_at([1, 1, 1]).unwrap();
 
+        assert!(matches!(octree.get([1, 1, 1]), Some(0)));
+        assert!(matches!(octree.get([0, 0, 0]), Some(1)));
+    }
+
+
+    #[test]
+    fn basic_serialization() {
+        let mut octree = Octree::<u8>::new(NonZeroU32::new(32).unwrap()).unwrap();
+        octree.insert([0, 0, 0], 1).unwrap();
+        octree.insert([0, 0, 1], 1).unwrap();
+        octree.insert([0, 1, 0], 1).unwrap();
+        octree.insert([0, 1, 1], 1).unwrap();
+        octree.insert([1, 0, 0], 1).unwrap();
+        octree.insert([1, 0, 1], 1).unwrap();
+        octree.insert([1, 1, 0], 1).unwrap();
+        octree.insert([1, 1, 1], 1).unwrap();
+
+        octree.clear_at([1, 1, 1]).unwrap();
+
+        assert!(matches!(octree.get([1, 1, 1]), Some(0)));
+        assert!(matches!(octree.get([0, 0, 0]), Some(1)));
+
+        let serialized = octree.to_bencode().unwrap();
+        let octree: octree::Octree<u8> = Octree::from_bencode(&serialized).unwrap();
         assert!(matches!(octree.get([1, 1, 1]), Some(0)));
         assert!(matches!(octree.get([0, 0, 0]), Some(1)));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ mod tests {
     }
 
     #[test]
-    fn indexed_access() {
+    fn dense_access_diverse_values() {
         const DIM: u32 = 32;
         let mut octree = Octree::<u32>::new(NonZeroU32::new(DIM as u32).unwrap()).unwrap();
         for x in 0..DIM {
@@ -81,7 +81,36 @@ mod tests {
                     let result = octree.get([x as u32, y as u32, z as u32]);
                     assert!(result.is_some());
                     if let Some(value) = result {
-                        assert!(*value == expected);
+                        assert_eq!(*value, expected);
+                    };
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dense_access_inflexible_values() {
+        const DIM: u32 = 32;
+        let mut octree = Octree::<u32>::new(NonZeroU32::new(DIM as u32).unwrap()).unwrap();
+        let data_field = |x: u32, y: u32, z: u32| -> u32 {
+            (((x as f32).sin() + (y as f32).sin() + (z as f32).sin()).min(-1.) * -100.) as u32
+        };
+        for x in 0..DIM {
+            for y in 0..DIM {
+                for z in 0..DIM {
+                    let result = octree.insert([x as u32, y as u32, z as u32], data_field(x, y, z));
+                    assert!(result.is_ok());
+                }
+            }
+        }
+
+        for x in 0..DIM {
+            for y in 0..DIM {
+                for z in 0..DIM {
+                    let result = octree.get([x as u32, y as u32, z as u32]);
+                    assert!(result.is_some());
+                    if let Some(value) = result {
+                        assert_eq!(*value, data_field(x, y, z));
                     };
                 }
             }
@@ -99,22 +128,25 @@ mod tests {
         octree.insert([1, 0, 1], 1).unwrap();
         octree.insert([1, 1, 0], 1).unwrap();
         octree.insert([1, 1, 1], 1).unwrap();
+        octree.insert([2, 2, 2], 2).unwrap();
 
         octree.clear_at([1, 1, 1]).unwrap();
 
         assert!(matches!(octree.get([1, 1, 1]), Some(0)));
         assert!(matches!(octree.get([0, 0, 0]), Some(1)));
+        assert!(matches!(octree.get([2, 2, 2]), Some(2)));
 
         let serialized = octree.to_bencode().unwrap();
         let octree: octree::Octree<u8> = Octree::from_bencode(&serialized).unwrap();
         assert!(matches!(octree.get([1, 1, 1]), Some(0)));
         assert!(matches!(octree.get([0, 0, 0]), Some(1)));
+        assert!(matches!(octree.get([2, 2, 2]), Some(2)));
     }
 
     // #[test]
     // fn test() {
     //     let mut octree = Octree::<u8>::new(NonZeroU32::new(32).unwrap()).unwrap();
-        
+
     //     octree.insert([0, 0, 0], 1).unwrap();
     //     octree.insert([0, 0, 1], 1).unwrap();
     //     octree.insert([0, 1, 0], 1).unwrap();
@@ -124,33 +156,33 @@ mod tests {
     //     octree.insert([1, 1, 0], 1).unwrap();
     //     octree.insert([1, 1, 1], 1).unwrap();
 
-        // octree.insert([0, 0, 2], 2).unwrap();
-        // octree.insert([1, 0, 2], 2).unwrap();
-        // octree.insert([0, 0, 3], 2).unwrap();
-        // octree.insert([1, 0, 3], 2).unwrap();
-        // octree.insert([0, 1, 2], 2).unwrap();
-        // octree.insert([1, 1, 2], 2).unwrap();
-        // octree.insert([0, 1, 3], 2).unwrap();
-        // octree.insert([1, 1, 3], 2).unwrap();
+    // octree.insert([0, 0, 2], 2).unwrap();
+    // octree.insert([1, 0, 2], 2).unwrap();
+    // octree.insert([0, 0, 3], 2).unwrap();
+    // octree.insert([1, 0, 3], 2).unwrap();
+    // octree.insert([0, 1, 2], 2).unwrap();
+    // octree.insert([1, 1, 2], 2).unwrap();
+    // octree.insert([0, 1, 3], 2).unwrap();
+    // octree.insert([1, 1, 3], 2).unwrap();
 
-        // octree.insert([0, 2, 0], 3).unwrap();
-        // octree.insert([1, 2, 0], 3).unwrap();
-        // octree.insert([0, 2, 1], 3).unwrap();
-        // octree.insert([1, 2, 1], 3).unwrap();
-        // octree.insert([0, 3, 0], 3).unwrap();
-        // octree.insert([1, 3, 0], 3).unwrap();
-        // octree.insert([0, 3, 1], 3).unwrap();
-        // octree.insert([1, 3, 1], 3).unwrap();
+    // octree.insert([0, 2, 0], 3).unwrap();
+    // octree.insert([1, 2, 0], 3).unwrap();
+    // octree.insert([0, 2, 1], 3).unwrap();
+    // octree.insert([1, 2, 1], 3).unwrap();
+    // octree.insert([0, 3, 0], 3).unwrap();
+    // octree.insert([1, 3, 0], 3).unwrap();
+    // octree.insert([0, 3, 1], 3).unwrap();
+    // octree.insert([1, 3, 1], 3).unwrap();
 
-        // octree.insert([2, 0, 0], 4).unwrap();
-        // octree.insert([3, 0, 0], 4).unwrap();
-        // octree.insert([2, 0, 1], 4).unwrap();
-        // octree.insert([3, 0, 1], 4).unwrap();
-        // octree.insert([2, 1, 0], 4).unwrap();
-        // octree.insert([3, 1, 0], 4).unwrap();
-        // octree.insert([2, 1, 1], 4).unwrap();
-        // octree.insert([3, 1, 1], 4).unwrap();
+    // octree.insert([2, 0, 0], 4).unwrap();
+    // octree.insert([3, 0, 0], 4).unwrap();
+    // octree.insert([2, 0, 1], 4).unwrap();
+    // octree.insert([3, 0, 1], 4).unwrap();
+    // octree.insert([2, 1, 0], 4).unwrap();
+    // octree.insert([3, 1, 0], 4).unwrap();
+    // octree.insert([2, 1, 1], 4).unwrap();
+    // octree.insert([3, 1, 1], 4).unwrap();
 
-        // println!("{:?}", octree);
+    // println!("{:?}", octree);
     // }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -135,7 +135,13 @@ where
     }
 
     /// Inserts a new leaf `Node` at the given position, if possible.
-    pub(crate) fn insert(&mut self, position: Vector3<u32>, min_dimension: u32, data: T) -> Result<(), Error> {
+    pub(crate) fn insert(
+        &mut self,
+        position: Vector3<u32>,
+        min_dimension: u32,
+        do_simplify: bool,
+        data: T,
+    ) -> Result<(), Error> {
         if !self.contains(position) {
             return Err(Error::InvalidPosition {
                 x: position.x,
@@ -146,7 +152,6 @@ where
 
         if self.dimension() == min_dimension {
             self.ty = NodeType::Leaf(data);
-            self.simplify();
             return Ok(());
         }
 
@@ -176,10 +181,12 @@ where
             }
         }
 
-        node.insert(position, min_dimension, data).unwrap();
+        node.insert(position, min_dimension, do_simplify, data).unwrap();
         self.children[octant as usize] = Box::new(Some(node));
         self.ty = NodeType::Internal;
-        self.simplify();
+        if do_simplify {
+            self.simplify();
+        }
         Ok(())
     }
 
@@ -280,6 +287,32 @@ where
         self.ty = NodeType::Leaf((*data.unwrap()).clone());
         self.children.fill(Box::new(None));
         true
+    }
+
+    /// Simplifies node and children recursively
+    pub(crate) fn simplify_recursive(&mut self) -> bool {
+        let mut leaf_children = 0;
+        for i in 0..OCTREE_CHILDREN {
+            if let Some(child) = self.children[i].deref_mut() {
+                match child.ty {
+                    NodeType::Internal => {
+                        if child.simplify_recursive() {
+                            leaf_children += 1
+                        }
+                    }
+                    NodeType::Leaf(_) => {
+                        leaf_children += 1;
+                    }
+                };
+            } else {
+                return false;
+            }
+        }
+        if leaf_children == OCTREE_CHILDREN {
+            self.simplify()
+        } else {
+            false
+        }
     }
 
     /// Returns a higher LOD of the current `Node`.
@@ -545,7 +578,6 @@ where
                 // for n in all_nodes.iter() {
                 //     let d_ty = match n.0.as_ref().unwrap().ty {
                 //         NodeType::Internal => format!("INTERNAL"),
-                //         NodeType::Simplified => format!("SIMPLIFIED"),
                 //         NodeType::Leaf(d) => format!("{:?}", d),
                 //     };
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,9 +2,9 @@ use crate::{Error, Vector3};
 
 use hashbrown::HashMap;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, vec::Vec};
 use core::{
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     hash::Hash,
     ops::{Deref, DerefMut},
 };
@@ -387,5 +387,234 @@ where
 
     fn is_leaf(&self) -> bool {
         matches!(self.ty, NodeType::Leaf(_))
+    }
+}
+
+use bendy::encoding::{Error as BencodeError, SingleItemEncoder, ToBencode};
+impl<T> ToBencode for Node<T>
+where
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+{
+    const MAX_DEPTH: usize = 4;
+    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), BencodeError> {
+        //Collect al Nodes into an array for serialization
+        let mut all_nodes = Vec::<(&Node<T>, [Option<usize>; OCTREE_CHILDREN])>::new(); // Node reference and the index of each child in the same array
+        let mut nodes_to_process = VecDeque::new(); // Index values of unprocessed Nodes in `all_nodes`
+        nodes_to_process.push_front(0);
+        all_nodes.push((self, [None; OCTREE_CHILDREN]));
+        while 0 < nodes_to_process.len() {
+            let current_node_index = nodes_to_process.remove(0).unwrap();
+            assert!(
+                current_node_index < all_nodes.len(),
+                "Node to process out of bounds! {current_node_index} / {:?}",
+                all_nodes.len()
+            );
+            let (current_node, mut indexed_children) = all_nodes[current_node_index];
+            for i in 0..OCTREE_CHILDREN {
+                if let Some(c) = current_node.children[i].as_ref() {
+                    //If the yet unprocessed Node has a child; push it to the end of the `all_nodes` vector, and mark it to be processed
+                    indexed_children[i] = Some(all_nodes.len());
+                    nodes_to_process.push_back(all_nodes.len());
+                    all_nodes.push((c, [None; OCTREE_CHILDREN]));
+                }
+            }
+            all_nodes[current_node_index] = (current_node, indexed_children);
+        }
+
+        // println!("Encode:");
+        // let mut n_i = 0;
+        // for n in all_nodes.iter() {
+        //     let d_ty = match n.0.ty {
+        //         NodeType::Internal => format!("INTERNAL"),
+        //         NodeType::Simplified => format!("SIMPLIFIED"),
+        //         NodeType::Leaf(d) => format!("{:?}", d),
+        //     };
+
+        //     let d_bounds = format!("{:?};{:?}", n.0.bounds[0], n.0.bounds[1]);
+        //     let mut d_children = "[".to_owned();
+        //     for c in n.1 {
+        //         match c {
+        //             Some(index) => d_children.push_str(format!("{index},").as_str()),
+        //             _ => d_children.push_str("x,"),
+        //         }
+        //     }
+        //     d_children.push_str("]");
+        //     println!("Nodes[{}]: [{}][{}]:{}", n_i, d_ty, d_bounds, d_children);
+        //     n_i += 1;
+        // }
+
+        // Serialize the array
+        encoder.emit_list(|e| {
+            e.emit_int(all_nodes.len())?;
+            for (node_ref, node_children) in all_nodes.iter() {
+                //emit Node without children
+                match node_ref.ty {
+                    NodeType::Internal => e.emit_str("###iNtErNaL###")?,
+                    NodeType::Simplified => e.emit_str("###SiMpLiFiEd###")?,
+                    NodeType::Leaf(d) => {
+                        e.emit_str("###lEaF###")?;
+                        e.emit(d)?
+                    }
+                }
+                //emit bounds
+                let mut bytes = Vec::<u8>::with_capacity(BOUNDS_LEN * 3);
+                node_ref.bounds.iter().for_each(|vec| {
+                    Into::<[u32; 3]>::into(*vec)
+                        .iter()
+                        .for_each(|b| bytes.extend_from_slice(&b.to_be_bytes()));
+                });
+                e.emit_bytes(&bytes)?;
+                //emit Node child array index values
+                e.emit_list(|e2| {
+                    // the value 0 can be used safely here, becaue the root node is at index 0; and it's child for noone
+                    for i in 0..OCTREE_CHILDREN {
+                        e2.emit_int(node_children[i].unwrap_or(0))?;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(())
+        })
+    }
+}
+
+use bendy::decoding::{FromBencode, Object};
+impl<T> FromBencode for Node<T>
+where
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + FromBencode,
+{
+    fn decode_bencode_object(data: Object) -> Result<Self, bendy::decoding::Error> {
+        //Read in serialized array containing Node information
+        match data {
+            Object::List(mut list) => {
+                let mut all_nodes = Vec::<(Option<Node<T>>, [Option<usize>; OCTREE_CHILDREN])>::new(); // The actual Node to be built and the helper index values for its children
+                let node_count = match list.next_object()?.unwrap() {
+                    Object::Integer(i) => Ok(i.parse().unwrap()),
+                    _ => Err(bendy::decoding::Error::unexpected_token(
+                        "Integer, size of all_nodes Vec",
+                        "Something else",
+                    )),
+                }?;
+
+                for _ in 0..node_count {
+                    use std::string::String;
+                    let mut is_leaf = false;
+                    let mut ty = match String::decode_bencode_object(list.next_object()?.unwrap())?.as_str() {
+                        "###iNtErNaL###" => Ok(NodeType::Internal),
+                        "###SiMpLiFiEd###" => Ok(NodeType::Simplified),
+                        "###lEaF###" => {
+                            is_leaf = true;
+                            Ok(NodeType::Simplified)
+                        }
+                        s => Err(bendy::decoding::Error::unexpected_token(
+                            "NodeType markers",
+                            format!("{:?}", s),
+                        )),
+                    }?;
+                    if is_leaf {
+                        ty = NodeType::<T>::Leaf(T::decode_bencode_object(list.next_object()?.unwrap())?)
+                    }
+                    let bounds = match list.next_object()?.unwrap() {
+                        Object::Bytes(b) => {
+                            let bounds_vector: Vec<[u32; 3]> = b
+                                .chunks(4)
+                                .map(|c| u32::from_be_bytes(c.try_into().unwrap()))
+                                .collect::<Vec<_>>()
+                                .chunks(3)
+                                .map(|c| <[_; 3]>::try_from(c).unwrap())
+                                .collect();
+                            Ok(bounds_vector)
+                        }
+                        _ => Err(bendy::decoding::Error::unexpected_token("Bytes", "not Bytes")),
+                    }?;
+                    let mut children: [Option<usize>; OCTREE_CHILDREN] = [None; OCTREE_CHILDREN];
+                    match list.next_object()?.unwrap() {
+                        Object::List(mut child_list) => Ok(for i in 0..OCTREE_CHILDREN {
+                            children[i] = match child_list.next_object()?.unwrap() {
+                                Object::Integer(i) => Ok(Some(i.parse::<usize>().unwrap())),
+                                _ => Err(bendy::decoding::Error::unexpected_token("List", "not List")),
+                            }?;
+                            if children[i].unwrap() == 0 {
+                                // 0 index value represents None in the helper index structure
+                                children[i] = None;
+                            }
+                        }),
+                        _ => Err(bendy::decoding::Error::unexpected_token("List", "not List")),
+                    }?;
+                    all_nodes.push((
+                        Some(Node::<T> {
+                            ty,
+                            bounds: [bounds[0].into(), bounds[1].into()],
+                            ..Default::default()
+                        }),
+                        children,
+                    ));
+                }
+
+                // println!("Decode:");
+                // let mut n_i = 0;
+                // for n in all_nodes.iter() {
+                //     let d_ty = match n.0.as_ref().unwrap().ty {
+                //         NodeType::Internal => format!("INTERNAL"),
+                //         NodeType::Simplified => format!("SIMPLIFIED"),
+                //         NodeType::Leaf(d) => format!("{:?}", d),
+                //     };
+
+                //     let d_bounds = format!(
+                //         "{:?};{:?}",
+                //         n.0.as_ref().unwrap().bounds[0],
+                //         n.0.as_ref().unwrap().bounds[1]
+                //     );
+                //     let mut d_children = "[".to_owned();
+                //     for c in n.1 {
+                //         match c {
+                //             Some(index) => d_children.push_str(format!("{index},").as_str()),
+                //             _ => d_children.push_str("x,"),
+                //         }
+                //     }
+                //     d_children.push_str("]");
+                //     println!("Nodes[{}]: [{}][{}]:{}", n_i, d_ty, d_bounds, d_children);
+                //     n_i += 1;
+                // }
+
+                //Construct the tree structure from the serialized array
+                let mut stack: VecDeque<(usize, usize, usize)> = VecDeque::new(); // Index of the Node, and index of its parent(who put it on the stack) along with the index of the child the Node is(parent's child index)
+                stack.push_back((0, 0, 0));
+
+                while 0 < stack.len() {
+                    let (current_node, current_node_parent, parent_child_index) = stack.back().unwrap();
+                    let mut current_child_index = 0; //Also contains the index of the child in which the helper index values and the Node<T>.children contents differ
+                    for child_index in 0..OCTREE_CHILDREN {
+                        if all_nodes[*current_node].1[child_index].is_none() //If the helper inde value
+                            || all_nodes[*current_node].0.as_ref().unwrap().children[child_index].is_some()
+                        {
+                            current_child_index += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    if current_child_index < OCTREE_CHILDREN {
+                        stack.push_back((
+                            all_nodes[*current_node].1[current_child_index].unwrap(),
+                            *current_node,
+                            current_child_index,
+                        ));
+                    } else {
+                        //children are ready! let's push this item into a Box, add the dependency to its parent and remove it from stack!
+                        //except for the root Node
+                        if 0 != *current_node {
+                            // move box into its parent Node
+                            let boxed = Box::new(std::mem::replace(&mut all_nodes[*current_node].0, None)); //Move Node into a box
+                            all_nodes[*current_node_parent].0.as_mut().unwrap().children[*parent_child_index] = boxed;
+                        }
+                        stack.pop_back();
+                    }
+                }
+
+                // Return the root Node
+                Ok(std::mem::replace(&mut all_nodes[0].0, None).unwrap())
+            }
+            _ => Err(bendy::decoding::Error::unexpected_token("List", "not List")),
+        }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -93,7 +93,7 @@ impl Octant {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 enum NodeType<T> {
     Leaf(T),
     Internal,

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -149,7 +149,7 @@ where
 
     /// Effectively increases the leaf dimension of the `Octree` and simplifies where possible.
     ///
-    /// Moves the leaf dimension up a level, and all leaves are formed by the most common data of their
+    /// Moves the leaf dimension down a level, and all leaves are formed by the most common data of their
     /// original children.
     ///
     /// # Example

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -6,7 +6,6 @@ use micromath::F32Ext;
 use alloc::boxed::Box;
 use core::{f32, fmt::Debug, hash::Hash, num::NonZeroU32};
 
-#[derive(Debug)]
 pub struct Octree<T>
 where
     T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash,

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -50,10 +50,7 @@ where
                 max_lod_level: max_depth.round() as u32,
                 min_dimension: 1,
                 auto_simplify: false,
-                root: Box::new(Node::<T>::new([
-                    Vector3::from([0, 0, 0]),
-                    Vector3::from([dimension.get(), dimension.get(), dimension.get()]),
-                ])),
+                root: Box::new(Node::<T>::new(Vector3::from([0, 0, 0]), dimension.get())),
             })
         } else {
             Err(Error::InvalidDimension(dimension.into()))
@@ -141,10 +138,7 @@ where
     /// assert!(matches!(octree.get([0, 0, 1]), Some(0)));
     /// ```
     pub fn clear(&mut self) {
-        self.root = Box::new(Node::<T>::new([
-            Vector3::from([0, 0, 0]),
-            Vector3::from([self.dimension.get(), self.dimension.get(), self.dimension.get()]),
-        ]));
+        self.root = Box::new(Node::<T>::new(Vector3::from([0, 0, 0]), self.dimension.into()));
     }
 
     /// Effectively increases the leaf dimension of the `Octree` and simplifies where possible.

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -4,11 +4,11 @@ use crate::{Error, Node, Vector3};
 use micromath::F32Ext;
 
 use alloc::boxed::Box;
-use core::{f32, fmt::Debug, hash::Hash, num::NonZeroU32};
+use core::{f32, hash::Hash, num::NonZeroU32};
 
 pub struct Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     dimension: NonZeroU32,
     curr_lod_level: u32,
@@ -19,7 +19,7 @@ where
 
 impl<T> Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     /// Creates a new `Octree<T>` of given dimension.
     ///
@@ -248,7 +248,7 @@ where
 use bendy::encoding::{SingleItemEncoder, ToBencode};
 impl<T> ToBencode for Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     const MAX_DEPTH: usize = 5; //TODO: does this need to include depth of the Node trait implementation?
     fn encode(&self, encoder: SingleItemEncoder) -> Result<(), bendy::encoding::Error> {
@@ -265,7 +265,7 @@ use bendy::decoding::{FromBencode, Object};
 
 impl<T> FromBencode for Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+    T: Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     fn decode_bencode_object(data: Object) -> Result<Self, bendy::decoding::Error> {
         match data {

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -8,7 +8,7 @@ use core::{f32, fmt::Debug, hash::Hash, num::NonZeroU32};
 
 pub struct Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash,
+    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     dimension: NonZeroU32,
     curr_lod_level: u32,
@@ -19,7 +19,7 @@ where
 
 impl<T> Octree<T>
 where
-    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash,
+    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
 {
     /// Creates a new `Octree<T>` of given dimension.
     ///
@@ -242,5 +242,76 @@ where
     /// ```
     pub fn contains(&self, position: [u32; 3]) -> bool {
         self.root.contains(position.into())
+    }
+}
+
+use bendy::encoding::{SingleItemEncoder, ToBencode};
+impl<T> ToBencode for Octree<T>
+where
+    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+{
+    const MAX_DEPTH: usize = 5; //TODO: does this need to include depth of the Node trait implementation?
+    fn encode(&self, encoder: SingleItemEncoder) -> Result<(), bendy::encoding::Error> {
+        encoder.emit_list(|e| {
+            e.emit_int(u32::from(self.dimension))?;
+            e.emit_int(self.curr_lod_level)?;
+            e.emit_int(self.max_lod_level)?;
+            e.emit_int(self.min_dimension)?;
+            e.emit(self.root.clone()) //TODO: Does this really need to be cloned?
+        })
+    }
+}
+use bendy::decoding::{FromBencode, Object};
+
+impl<T> FromBencode for Octree<T>
+where
+    T: Debug + Default + Clone + Eq + PartialEq + Copy + Hash + ToBencode + FromBencode,
+{
+    fn decode_bencode_object(data: Object) -> Result<Self, bendy::decoding::Error> {
+        match data {
+            Object::List(mut list) => {
+                let dimension = match list.next_object()?.unwrap() {
+                    Object::Integer(i) => Ok(i.parse::<NonZeroU32>().unwrap()),
+                    _ => Err(bendy::decoding::Error::unexpected_token(
+                        "Integer Octree dimension",
+                        "Something else",
+                    )),
+                }?;
+
+                let curr_lod_level = match list.next_object()?.unwrap() {
+                    Object::Integer(i) => Ok(i.parse::<u32>().unwrap()),
+                    _ => Err(bendy::decoding::Error::unexpected_token(
+                        "Integer Octree curr_lod_level",
+                        "Something else",
+                    )),
+                }?;
+
+                let max_lod_level = match list.next_object()?.unwrap() {
+                    Object::Integer(i) => Ok(i.parse::<u32>().unwrap()),
+                    _ => Err(bendy::decoding::Error::unexpected_token(
+                        "Integer Octree max_lod_level",
+                        "Something else",
+                    )),
+                }?;
+
+                let min_dimension = match list.next_object()?.unwrap() {
+                    Object::Integer(i) => Ok(i.parse::<u32>().unwrap()),
+                    _ => Err(bendy::decoding::Error::unexpected_token(
+                        "Integer Octree min_dimension",
+                        "Something else",
+                    )),
+                }?;
+
+                let root = Node::<T>::decode_bencode_object(list.next_object()?.unwrap())?;
+                Ok(Octree {
+                    dimension,
+                    curr_lod_level,
+                    max_lod_level,
+                    min_dimension,
+                    root: Box::new(root),
+                })
+            }
+            _ => Err(bendy::decoding::Error::unexpected_token("List", "not List")),
+        }
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Mul};
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct Vector3<T>
 where
     T: Copy,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -41,3 +41,9 @@ impl<T: Copy> From<[T; 3]> for Vector3<T> {
         }
     }
 }
+
+impl<T: Copy> Into<[T; 3]> for Vector3<T> {
+    fn into(self) -> [T; 3] {
+        [self.x, self.y, self.z]
+    }
+}


### PR DESCRIPTION
The performance increased significantly at insertion in case dense data when simplify is disabled, because lots of merging and splitting is spared. 
Calling simplify_recursive after the insertion also optimizes the octree, but with less overhead. 